### PR TITLE
fix(auth): handle edge case

### DIFF
--- a/cdispyutils/auth/__init__.py
+++ b/cdispyutils/auth/__init__.py
@@ -1,2 +1,6 @@
 from .errors import JWTValidationError, JWTAudienceError
-from .jwt_validation import validate_request_jwt, validate_jwt
+from .jwt_validation import (
+    get_public_key_for_kid,
+    validate_jwt,
+    validate_request_jwt,
+)

--- a/cdispyutils/auth/jwt_validation.py
+++ b/cdispyutils/auth/jwt_validation.py
@@ -173,6 +173,8 @@ def validate_request_jwt(
     request = request or flask.request
     try:
         encoded_token = request.headers['Authorization'].split(' ')[1]
+    except IndexError:
+        raise JWTValidationError('could not parse authorization header')
     except KeyError:
         raise JWTValidationError('no authorization token provided')
     token_headers = jwt.get_unverified_header(encoded_token)

--- a/test/auth/test_jwt.py
+++ b/test/auth/test_jwt.py
@@ -109,6 +109,13 @@ def test_validate_request_no_jwt_fails(client, mock_get):
         client.get('/test')
 
 
+def test_validate_request_jwt_bad_header(client, mock_get, encoded_jwt):
+    mock_get()
+    incorrect_headers = {'Authorization': encoded_jwt}
+    with pytest.raises(JWTValidationError):
+        client.get('/test', headers=incorrect_headers)
+
+
 def test_validate_request_jwt_incorrect_usage(
         app, client, auth_header, mock_get):
     """


### PR DESCRIPTION
- Export `get_public_key_for_kid` (needed in fence)
- Fix rogue `KeyError` which happens in `validate_request_jwt` if the header is malformed