### PR TITLE
PXD-2441: feat(uwsgi-user-harakiri): apply rev proxy timeout

### DIFF
--- a/cdispyutils/uwsgi.py
+++ b/cdispyutils/uwsgi.py
@@ -1,0 +1,56 @@
+from __future__ import absolute_import
+
+import time
+from flask import request, abort
+
+
+def setup_user_harakiri(app):
+    """Configure given Flask app to have automatic user harakiri.
+
+    Because a request may stay in uWSGI socket backlog for uncertain time, the reverse
+    proxy may time out during or even before the handling of the request, and uWSGI may
+    still handle the request with successful commitment. In order to avoid inconsistent
+    result, this feature sets the user harakiri timeout on a per-request basis based on
+    request arrival time and timeout values set by the reverse proxy as WSGI environment
+    variables.
+    """
+
+    try:
+        import uwsgi
+    except ImportError:
+        uwsgi = None
+    else:
+        if hasattr(uwsgi, "set_user_harakiri"):
+            app.logger.info("Enabling automatic harakiri...")
+        else:
+            uwsgi = None
+
+    @app.before_request
+    def apply_reverse_proxy_timeout():
+        timestamp = request.environ.get("GEN3_REQUEST_TIMESTAMP")
+        timeout = request.environ.get("GEN3_TIMEOUT_SECONDS")
+        if not timestamp or not timeout:
+            return None
+        timeout = float(timestamp) + float(timeout) - time.time()
+        if timeout < 1:
+            # We don't proceed if the time remaining is less than 1 second because the
+            # minimal harakiri time is 1 second. Therefore it is important to set
+            # GEN3_TIMEOUT_SECONDS larger than 1 second, not even close.
+            app.logger.info("Not enough time to handle the request; discarding now.")
+            abort(504)
+        if uwsgi:
+            # GOTCHA: the int here is intentional over round, because we need a smaller
+            # timeout than reverse proxy
+            timeout = int(timeout)
+            uwsgi.set_user_harakiri(timeout)
+            app.logger.debug("Set user harakiri in %d seconds.", timeout)
+
+    @app.teardown_request
+    def clear_harakiri(_):
+        if uwsgi:
+            try:
+                # Setting user harakiri to 0 means to clear pending timeout if any
+                uwsgi.set_user_harakiri(0)
+            except:
+                # teardown_request must not fail
+                app.logger.exception("Failed to clear user harakiri")

--- a/test/test_uwsgi.py
+++ b/test/test_uwsgi.py
@@ -1,0 +1,74 @@
+import flask
+import mock
+import pytest
+import time
+
+from cdispyutils import uwsgi
+
+
+@pytest.fixture
+def mod_uwsgi():
+    return mock.Mock()
+
+
+@pytest.fixture
+def app(mod_uwsgi):
+    app = flask.Flask("test")
+
+    @app.route("/")
+    def index():
+        return "", 200
+
+    # XXX: must not run tests within this `with` block
+    with mock.patch.dict("sys.modules", uwsgi=mod_uwsgi):
+        uwsgi.setup_user_harakiri(app)
+
+    return app
+
+
+def test_user_harakiri_no_effect_on_normal_requests(mod_uwsgi, app):
+    with app.test_client() as c:
+        assert c.get("/").status_code == 200
+    mod_uwsgi.set_user_harakiri.assert_called_once_with(0)
+
+
+def test_user_harakiri_with_environ(mod_uwsgi, app):
+    with app.test_client() as c:
+        assert (
+            c.get(
+                "/",
+                environ_overrides=dict(
+                    GEN3_REQUEST_TIMESTAMP=time.time(), GEN3_TIMEOUT_SECONDS="10.9"
+                ),
+            ).status_code
+            == 200
+        )
+    assert mod_uwsgi.set_user_harakiri.call_args_list == [mock.call(10), mock.call(0)]
+
+
+def test_user_harakiri_expired_in_backlog(mod_uwsgi, app):
+    with app.test_client() as c:
+        assert (
+            c.get(
+                "/",
+                environ_overrides=dict(
+                    GEN3_REQUEST_TIMESTAMP=time.time() - 20, GEN3_TIMEOUT_SECONDS="10.9"
+                ),
+            ).status_code
+            == 504
+        )
+    mod_uwsgi.set_user_harakiri.assert_called_once_with(0)
+
+
+def test_user_harakiri_less_than_1_sec(mod_uwsgi, app):
+    with app.test_client() as c:
+        assert (
+            c.get(
+                "/",
+                environ_overrides=dict(
+                    GEN3_REQUEST_TIMESTAMP=time.time(), GEN3_TIMEOUT_SECONDS="0.9"
+                ),
+            ).status_code
+            == 504
+        )
+    mod_uwsgi.set_user_harakiri.assert_called_once_with(0)


### PR DESCRIPTION
Because a request may stay in uWSGI socket backlog for uncertain time, the reverse proxy may time out during or even before the handling of the request, and uWSGI may still handle the request with successful commitment. In order to avoid inconsistent result, this feature sets the [user harakiri](https://uwsgi-docs.readthedocs.io/en/latest/PythonDecorators.html#uwsgidecorators.harakiri) timeout on a per-request basis based on request arrival time and timeout values set by the reverse proxy as WSGI environment variables.