### PR TITLE
feat(uwsgi): make timeout more compatible

### DIFF
--- a/cdispyutils/uwsgi.py
+++ b/cdispyutils/uwsgi.py
@@ -31,7 +31,7 @@ def setup_user_harakiri(app):
         timeout = request.environ.get("GEN3_TIMEOUT_SECONDS")
         if not timestamp or not timeout:
             return None
-        timeout = float(timestamp) + float(timeout) - time.time()
+        timeout = float(timestamp) + float(timeout.rstrip("s")) - time.time()
         if timeout < 1:
             # We don't proceed if the time remaining is less than 1 second because the
             # minimal harakiri time is 1 second. Therefore it is important to set

--- a/test/test_uwsgi.py
+++ b/test/test_uwsgi.py
@@ -35,10 +35,24 @@ def test_user_harakiri_no_effect_on_normal_requests(mod_uwsgi, app):
 def test_user_harakiri_with_environ(mod_uwsgi, app):
     with app.test_client() as c:
         assert (
+                c.get(
+                    "/",
+                    environ_overrides=dict(
+                        GEN3_REQUEST_TIMESTAMP=time.time(), GEN3_TIMEOUT_SECONDS="10.9"
+                    ),
+                ).status_code
+                == 200
+        )
+    assert mod_uwsgi.set_user_harakiri.call_args_list == [mock.call(10), mock.call(0)]
+
+
+def test_user_harakiri_nginx_compat(mod_uwsgi, app):
+    with app.test_client() as c:
+        assert (
             c.get(
                 "/",
                 environ_overrides=dict(
-                    GEN3_REQUEST_TIMESTAMP=time.time(), GEN3_TIMEOUT_SECONDS="10.9"
+                    GEN3_REQUEST_TIMESTAMP=time.time(), GEN3_TIMEOUT_SECONDS="10.9s"
                 ),
             ).status_code
             == 200


### PR DESCRIPTION
* GEN3_TIMEOUT_SECONDS now accepts both `45` and `45s`