### PR TITLE
fix/no-plus

### DIFF
--- a/cdispyutils/hmac4/hmac4_auth_generator.py
+++ b/cdispyutils/hmac4/hmac4_auth_generator.py
@@ -2,7 +2,7 @@ import hashlib
 import cdispyutils.constants as constants
 from . import hmac4_auth_parser as hmac4_parser
 import hmac
-from urllib.parse import urlparse, parse_qs, quote, unquote, quote_plus
+from urllib.parse import urlparse, parse_qs, quote, unquote
 
 
 def set_req_date(req, req_date):

--- a/cdispyutils/hmac4/hmac4_auth_generator.py
+++ b/cdispyutils/hmac4/hmac4_auth_generator.py
@@ -131,7 +131,7 @@ def generate_presigned_url(
         canonical_qs += "&" + key + "=" + querystring[key]
     canonical_qs = canonical_qs[1:]
     for key in sorted(additional_signed_qs.keys()):
-        canonical_qs += "&" + key + "=" + quote_plus(additional_signed_qs[key])
+        canonical_qs += "&" + key + "=" + quote(additional_signed_qs[key])
 
     url_parts = url.split("://")
     encoded_url = "://".join([quote(e) for e in url_parts])

--- a/cdispyutils/hmac4/hmac4_auth_generator.py
+++ b/cdispyutils/hmac4/hmac4_auth_generator.py
@@ -117,13 +117,13 @@ def generate_presigned_url(
 
     querystring = {}
     querystring[constants.AWS_ALGORITHM_KEY] = constants.AWS_ALGORITHM
-    querystring[constants.AWS_CREDENTIAL_KEY] = quote_plus(
+    querystring[constants.AWS_CREDENTIAL_KEY] = quote(
         "/".join([access_key, credential_scope])
     )
     querystring[constants.AWS_DATE_KEY] = request_date
     querystring[constants.AWS_EXPIRES_KEY] = str(expires)
     if session_token:
-        querystring["X-Amz-Security-Token"] = quote_plus(session_token)
+        querystring["X-Amz-Security-Token"] = quote(session_token)
     querystring[constants.AWS_SIGNED_HEADERS_KEY] = "host"
 
     canonical_qs = ""

--- a/cdispyutils/hmac4/hmac4_auth_generator.py
+++ b/cdispyutils/hmac4/hmac4_auth_generator.py
@@ -118,12 +118,12 @@ def generate_presigned_url(
     querystring = {}
     querystring[constants.AWS_ALGORITHM_KEY] = constants.AWS_ALGORITHM
     querystring[constants.AWS_CREDENTIAL_KEY] = quote(
-        "/".join([access_key, credential_scope])
+        "/".join([access_key, credential_scope]), safe=""
     )
     querystring[constants.AWS_DATE_KEY] = request_date
     querystring[constants.AWS_EXPIRES_KEY] = str(expires)
     if session_token:
-        querystring["X-Amz-Security-Token"] = quote(session_token)
+        querystring["X-Amz-Security-Token"] = quote(session_token, safe="")
     querystring[constants.AWS_SIGNED_HEADERS_KEY] = "host"
 
     canonical_qs = ""
@@ -131,7 +131,7 @@ def generate_presigned_url(
         canonical_qs += "&" + key + "=" + querystring[key]
     canonical_qs = canonical_qs[1:]
     for key in sorted(additional_signed_qs.keys()):
-        canonical_qs += "&" + key + "=" + quote(additional_signed_qs[key])
+        canonical_qs += "&" + key + "=" + quote(additional_signed_qs[key], safe="")
 
     url_parts = url.split("://")
     encoded_url = "://".join([quote(e) for e in url_parts])

--- a/test/hmac4/test_hmac4.py
+++ b/test/hmac4/test_hmac4.py
@@ -30,7 +30,7 @@ def request_from_text(text):
 
     """
     lines = text.splitlines()
-    match = re.search("^([a-z]+) (.*) (http/[0-9]\.[0-9])$", lines[0], re.I)
+    match = re.search(r"^([a-z]+) (.*) (http/[0-9]\.[0-9])$", lines[0], re.I)
     method, path, version = match.groups()
     headers = {}
     for idx, line in enumerate(lines[1:], start=1):
@@ -193,7 +193,7 @@ def test_generate_presigned_url():
     cred = {
         "aws_access_key_id": "AKIDEXAMPLE",
         "aws_secret_access_key": "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
-        "aws_session_token": "FQoDYXdzEPv//////////wEaDD/RcZIzhOP3tz1Ut7NW7jud8VV53T59A2TNO2ZXkt",
+        "aws_session_token": "FQoDYXdzEPv//////////wEaDD/RcZIzhOP3tz1Ut7N W7jud8VV53T59A2TNO2ZXkt",
     }
     url = "https://s3.amazonaws.com/cdis-presigned-url-test/testdata"
     date = datetime.date(2018, 2, 19)
@@ -217,8 +217,8 @@ def test_generate_presigned_url():
         "&X-Amz-SignedHeaders=host"
         "&user-id=value2"
         "&username=value1%40gmail.com"
-        "&X-Amz-Signature=89af63e98712c6947d163c6c873a2b419b33a3c724ecd64c9fd6ddaf487fd4f9".format(
-            url, quote_plus(cred.get("aws_session_token"))
+        "&X-Amz-Signature=e63e7c291b2c89abf7a94ca1ed7438862feaadffc47a0c925723798ffb5a9bea".format(
+            url, quote(cred.get("aws_session_token"), safe="")
         )
     )
     assert presigned_url == expected
@@ -239,7 +239,7 @@ def test_generate_presigned_url_escaped():
             "s3",
             "us-east-1",
             86400,
-            {"user-id": "value2", "username": "value1@gmail.com"},
+            {"user-id": "value2", "username": "value1 (value3)@gmail.com"},
         )
 
     expected = (
@@ -250,7 +250,7 @@ def test_generate_presigned_url_escaped():
         "&X-Amz-Expires=86400"
         "&X-Amz-SignedHeaders=host"
         "&user-id=value2"
-        "&username=value1%40gmail.com"
-        "&X-Amz-Signature=ad46ace7fb67bf21f6bda544711c04dea3942c38da3099f037e441b6bdcc12b1"
+        "&username=value1%20%28value3%29%40gmail.com"
+        "&X-Amz-Signature=b4ac7428943c9801746b6d00112d3ae76739d79ee3e8e73070110979ddab4a1d"
     )
     assert presigned_url == expected


### PR DESCRIPTION
According to https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
> Percent-encode all other characters with %XY, where X and Y are hexadecimal characters (0-9 and uppercase A-F). For example, the space character must be encoded as %20 (not using '+', as some encoding schemes do) and extended UTF-8 characters must be in the form %XY%ZA%BC.

This is causing `403 signature does not match` error for generated S3 signed URL 


### Bug Fixes
- use `quote` instead of `quote_plus` for aws query string parsing


